### PR TITLE
[python] Fix a bug during initialization phase introduced by #2f5d2c6

### DIFF
--- a/src/dynamic_graph/sot/pyrene/robot.py
+++ b/src/dynamic_graph/sot/pyrene/robot.py
@@ -48,8 +48,7 @@ class Robot(Talos):
                 [ 0., 0.])
 
     def __init__(self, name, device=None, tracer=None, fromRosParam=None):
-        Talos.__init__(self, name, device, tracer,
-                fromRosParam=fromRosParam)
+        Talos.__init__(self, name, device=device, tracer=tracer, fromRosParam=fromRosParam)
         """
         TODO:Confirm these values
         # Define camera positions w.r.t gaze.

--- a/src/dynamic_graph/sot/talos/talos.py
+++ b/src/dynamic_graph/sot/talos/talos.py
@@ -51,7 +51,7 @@ class Talos(AbstractHumanoidRobot):
         res = config[0:27] + 7 * (0., ) + config[27:34] + 7 * (0., ) + config[34:]
         return res
 
-    def __init__(self, name, initialConfig, device=None, tracer=None, fromRosParam=False):
+    def __init__(self, name, device=None, tracer=None, fromRosParam=False):
         self.OperationalPointsMap = {
             'left-wrist': 'arm_left_7_joint',
             'right-wrist': 'arm_right_7_joint',
@@ -80,6 +80,8 @@ class Talos(AbstractHumanoidRobot):
         assert hasattr(self, "pinocchioModel")
         assert hasattr(self, "pinocchioData")
 
+	if device!=None:
+	    self.device = device
         AbstractHumanoidRobot.__init__(self, name, tracer)
 
         self.OperationalPoints.append('waist')
@@ -92,7 +94,6 @@ class Talos(AbstractHumanoidRobot):
         self.dynamic.displayModel()
         self.dimension = self.dynamic.getDimension()
 
-        self.device = device
         self.initializeRobot()
 
         self.AdditionalFrames.append(

--- a/src/dynamic_graph/sot/talos/talos.py
+++ b/src/dynamic_graph/sot/talos/talos.py
@@ -3,11 +3,13 @@
 
 from __future__ import print_function
 
+import pinocchio
+
 from dynamic_graph import plug
 from dynamic_graph.sot.core.math_small_entities import Derivator_of_Vector
 from dynamic_graph.sot.dynamic_pinocchio import DynamicPinocchio
-from dynamic_graph.sot.dynamic_pinocchio.humanoid_robot import AbstractHumanoidRobot
-import pinocchio
+from dynamic_graph.sot.dynamic_pinocchio.humanoid_robot import \
+    AbstractHumanoidRobot
 from rospkg import RosPack
 
 
@@ -70,18 +72,17 @@ class Talos(AbstractHumanoidRobot):
                 raise RuntimeError('"' + rosParamName + '" is not a ROS parameter.')
             s = rospy.get_param(rosParamName)
 
-            self.loadModelFromString(s, rootJointType=pinocchio.JointModelFreeFlyer,
-                    removeMimicJoints=True)
+            self.loadModelFromString(s, rootJointType=pinocchio.JointModelFreeFlyer, removeMimicJoints=True)
         else:
             self.loadModelFromUrdf(self.defaultFilename,
-                    rootJointType=pinocchio.JointModelFreeFlyer,
-                    removeMimicJoints=True)
+                                   rootJointType=pinocchio.JointModelFreeFlyer,
+                                   removeMimicJoints=True)
 
         assert hasattr(self, "pinocchioModel")
         assert hasattr(self, "pinocchioData")
 
-	if device!=None:
-	    self.device = device
+        if device != None:
+            self.device = device
         AbstractHumanoidRobot.__init__(self, name, tracer)
 
         self.OperationalPoints.append('waist')

--- a/src/dynamic_graph/sot/talos/talos.py
+++ b/src/dynamic_graph/sot/talos/talos.py
@@ -81,7 +81,7 @@ class Talos(AbstractHumanoidRobot):
         assert hasattr(self, "pinocchioModel")
         assert hasattr(self, "pinocchioData")
 
-        if device != None:
+        if device is not None:
             self.device = device
         AbstractHumanoidRobot.__init__(self, name, tracer)
 


### PR DESCRIPTION
If the device is provided in argument then the robot already exist and no simulation is needed.
On talos.py the useless initialConfig argument is removed
Fix #22