### PR TITLE
Implementing SoT parameter-server reading of the robot model to fix issue #24

### DIFF
--- a/src/dynamic_graph/sot/talos/talos.py
+++ b/src/dynamic_graph/sot/talos/talos.py
@@ -10,6 +10,7 @@ from dynamic_graph.sot.core.math_small_entities import Derivator_of_Vector
 from dynamic_graph.sot.dynamic_pinocchio import DynamicPinocchio
 from dynamic_graph.sot.dynamic_pinocchio.humanoid_robot import \
     AbstractHumanoidRobot
+from dynamic_graph.sot.core.parameter_server import ParameterServer
 from rospkg import RosPack
 
 
@@ -67,12 +68,15 @@ class Talos(AbstractHumanoidRobot):
         if fromRosParam:
             print("Using ROS parameter \"/robot_description\"")
             rosParamName = "/robot_description"
-            import rospy
-            if rosParamName not in rospy.get_param_names():
-                raise RuntimeError('"' + rosParamName + '" is not a ROS parameter.')
-            s = rospy.get_param(rosParamName)
-
-            self.loadModelFromString(s, rootJointType=pinocchio.JointModelFreeFlyer, removeMimicJoints=True)
+            self.param_server = ParameterServer("param_server")
+            self.param_server.init_simple()
+            model2_string=self.param_server.getParameter(rosParamName)
+            print("Start model2_string")
+            print(model2_string)
+            print("Stop model2_string")
+            self.loadModelFromString(model2_string,
+                                     rootJointType=pinocchio.JointModelFreeFlyer,
+                                     removeMimicJoints=True)
         else:
             self.loadModelFromUrdf(self.defaultFilename,
                                    rootJointType=pinocchio.JointModelFreeFlyer,

--- a/src/dynamic_graph/sot/talos/talos.py
+++ b/src/dynamic_graph/sot/talos/talos.py
@@ -11,7 +11,6 @@ from dynamic_graph.sot.dynamic_pinocchio import DynamicPinocchio
 from dynamic_graph.sot.dynamic_pinocchio.humanoid_robot import \
     AbstractHumanoidRobot
 from dynamic_graph.sot.core.parameter_server import ParameterServer
-from rospkg import RosPack
 
 
 # Internal helper tool.
@@ -66,14 +65,15 @@ class Talos(AbstractHumanoidRobot):
         }
 
         if fromRosParam:
-            print("Using ROS parameter \"/robot_description\"")
-            rosParamName = "/robot_description"
+            ltimeStep=0.005
+            if device is not None:
+                ltimeStep = device.getTimeStep()
+
+            print("Using SoT parameter \"/robot_description\"")
+            paramName = "/robot_description"
             self.param_server = ParameterServer("param_server")
-            self.param_server.init_simple()
-            model2_string=self.param_server.getParameter(rosParamName)
-            print("Start model2_string")
-            print(model2_string)
-            print("Stop model2_string")
+            self.param_server.init_simple(ltimeStep)
+            model2_string=self.param_server.getParameter(paramName)
             self.loadModelFromString(model2_string,
                                      rootJointType=pinocchio.JointModelFreeFlyer,
                                      removeMimicJoints=True)


### PR DESCRIPTION
This PR changes the talos.py to read the model provided by the parameter-server entity.
It is used in conjunction with:
 * Extend slightly parameter-server to fix sot-talos issues/24 stack-of-tasks/sot-core#145
Open
 * Read robot_description parameter for initialization stack-of-tasks/dynamic_graph_bridge#74 

It was checked on the robot this morning.
A full walking experiment on the robot will take a bit more time but all the PRs have been validated with talos_integration_tests with the exception of online_walking.

So I would say that it can be merged  (the concept is working) but for the release sot-torque-control, sot-talos-balance and talos_integration_tests need to reflect all the changes.