### PR TITLE
Update informations for feet for TALOS + python format

### DIFF
--- a/src/dynamic_graph/sot/pyrene/prologue.py
+++ b/src/dynamic_graph/sot/pyrene/prologue.py
@@ -28,7 +28,8 @@ def makeRobot():
     DeviceTalos = PyEntityFactoryClass('DeviceTalos')
 
     # Create the robot using the device.
-    robot = Robot(name='talos', device=DeviceTalos('PYRENE'), fromRosParam=True)
+    robot = Robot(name='talos', device=DeviceTalos('PYRENE'),
+                  fromRosParam=True)
     robot.dynamic.com.recompute(0)
     _com = robot.dynamic.com.value
     robot.device.zmp.value = (_com[0], _com[1], 0.)

--- a/src/dynamic_graph/sot/pyrene/robot.py
+++ b/src/dynamic_graph/sot/pyrene/robot.py
@@ -9,46 +9,58 @@ class Robot(Talos):
     This class instantiates LAAS TALOS Robot
     """
 
-    def defineHalfSitting (self, q):
+    def defineHalfSitting(self, q):
         """
         q is the configuration to fill.
 
-        When this function is called, the attribute pinocchioModel has been filled.
+        When this function is called,
+        the attribute pinocchioModel has been filled.
         """
-        model = self.pinocchioModel
         # Free flyer
         q[2] = 1.018213
         # left leg
         self.setJointValueInConfig(q,
-                [ "leg_left_{}_joint".format(i+1) for i in range(6) ],
-                [ 0., 0., -0.411354, 0.859395, -0.448041, -0.001708,])
+                                   ["leg_left_{}_joint".format(i+1)
+                                    for i in range(6)],
+                                   [0., 0., -0.411354, 0.859395,
+                                    -0.448041, -0.001708])
         # right leg
         self.setJointValueInConfig(q,
-                [ "leg_right_{}_joint".format(i+1) for i in range(6) ],
-                [ 0., 0., -0.411354, 0.859395, -0.448041, -0.001708,])
+                                   ["leg_right_{}_joint".format(i+1)
+                                    for i in range(6)],
+                                   [0., 0., -0.411354, 0.859395,
+                                    -0.448041, -0.001708])
         # torso
         self.setJointValueInConfig(q,
-                [ "torso_{}_joint".format(i+1) for i in range(2) ],
-                [ 0., 0.006761])
+                                   ["torso_{}_joint".format(i+1)
+                                    for i in range(2)],
+                                   [0., 0.006761])
         # left arm
         self.setJointValueInConfig(q,
-                [ "arm_left_{}_joint".format(i+1) for i in range(7) ],
-                [ 0.25847, 0.173046, -0.0002, -0.525366, 0., -0., 0.1 ])
+                                   ["arm_left_{}_joint".format(i+1)
+                                    for i in range(7)],
+                                   [0.25847, 0.173046, -0.0002,
+                                    -0.525366, 0., -0., 0.1])
         # right arm
         self.setJointValueInConfig(q,
-                [ "arm_right_{}_joint".format(i+1) for i in range(7) ],
-                [ -0.25847, -0.173046, 0.0002, -0.525366, 0., 0., 0.1 ])
+                                   ["arm_right_{}_joint".format(i+1)
+                                    for i in range(7)],
+                                   [-0.25847, -0.173046, 0.0002,
+                                    -0.525366, 0., 0., 0.1])
         # grippers
         self.setJointValueInConfig(q,
-                [ "gripper_left_joint", "gripper_right_joint" ],
-                [ -0.005, -0.005 ])
+                                   ["gripper_left_joint",
+                                    "gripper_right_joint"],
+                                   [-0.005, -0.005])
         # torso
         self.setJointValueInConfig(q,
-                [ "head_{}_joint".format(i+1) for i in range(2) ],
-                [ 0., 0.])
+                                   ["head_{}_joint".format(i+1)
+                                    for i in range(2)],
+                                   [0., 0.])
 
     def __init__(self, name, device=None, tracer=None, fromRosParam=None):
-        Talos.__init__(self, name, device=device, tracer=tracer, fromRosParam=fromRosParam)
+        Talos.__init__(self, name, device=device, tracer=tracer,
+                       fromRosParam=fromRosParam)
         """
         TODO:Confirm these values
         # Define camera positions w.r.t gaze.

--- a/src/dynamic_graph/sot/pyrene/seqplay.py
+++ b/src/dynamic_graph/sot/pyrene/seqplay.py
@@ -26,7 +26,8 @@ def convert(filename):
     openhrpZmp = np.genfromtxt(filename + '.zmp')
     nbConfig = len(openhrpPos)
     if len(openhrpZmp) != nbConfig:
-        raise RuntimeError(filename + ".pos and " + filename + ".zmp have different lengths.")
+        raise RuntimeError(filename + ".pos and " + filename +
+                           ".zmp have different lengths.")
     try:
         openhrpHip = np.genfromtxt(filename + '.hip')
     except IOError:
@@ -41,7 +42,8 @@ def convert(filename):
         openhrpHip = np.array(hip)
 
     if len(openhrpHip) != nbConfig:
-        raise RuntimeError(filename + ".pos and " + filename + ".hip have different lengths.")
+        raise RuntimeError(filename + ".pos and " + filename +
+                           ".hip have different lengths.")
 
     t = 1
     featurePos = []
@@ -114,8 +116,10 @@ def convert(filename):
             0.,
         ))
         t += 1
-        fixedLeftFoot = SE3(robot.leftAnkle.position.value) * R3(0., 0., -0.107)
-        fixedRightFoot = SE3(robot.rightAnkle.position.value) * R3(0., 0., -0.107)
+        fixedLeftFoot = SE3(robot.leftAnkle.position.value) \
+            * R3(0., 0., -0.107)
+        fixedRightFoot = SE3(robot.rightAnkle.position.value) \
+            * R3(0., 0., -0.107)
 
     filePos = open(filename + '.posture', 'w')
     fileLa = open(filename + '.la', 'w')
@@ -125,8 +129,9 @@ def convert(filename):
     fileFr = open(filename + '.fr', 'w')
 
     dt = .005
-    for (pos, la, ra, com, force_lf, force_rf, i) in zip(featurePos, featureLa, featureRa, featureCom, forceLeftFoot,
-                                                         forceRightFoot, range(10000000)):
+    for (pos, la, ra, com, force_lf, force_rf, i) in \
+        zip(featurePos, featureLa, featureRa, featureCom, forceLeftFoot,
+            forceRightFoot, range(10000000)):
         t = i * dt
         filePos.write("{0}".format(t))
         fileLa.write("{0}".format(t))

--- a/tests/run_motion_python_node.py
+++ b/tests/run_motion_python_node.py
@@ -100,6 +100,8 @@ if __name__ == '__main__':
     state = client.get_state()
 
     if action_ok:
-        rospy.loginfo("Action finished succesfully with state: " + str(get_status_string(state)))
+        rospy.loginfo("Action finished succesfully with state: "
+                      + str(get_status_string(state)))
     else:
-        rospy.logwarn("Action failed with state: " + str(get_status_string(state)))
+        rospy.logwarn("Action failed with state: "
+                      + str(get_status_string(state)))


### PR DESCRIPTION
[format] Makes flake8 happy.
Uses Parameter server to set:
 * Remapping of end effector bodies to canonical names: l_ankle, r_ankle, r_wrist, l_wrist to be used by sot-pattern-generator
 * Specify additional information of feet size on the ground.
