### PR TITLE
[Device] Copy robotState in state at initialization

### DIFF
--- a/src/sot-talos-device.cpp
+++ b/src/sot-talos-device.cpp
@@ -265,7 +265,13 @@ void SoTTalosDevice::setSensors(map<string, dgsot::SensorValues>& SensorsIn) {
   sotDEBUGOUT(25);
 }
 
-void SoTTalosDevice::setupSetSensors(map<string, dgsot::SensorValues>& SensorsIn) { setSensors(SensorsIn); }
+void SoTTalosDevice::setupSetSensors(map<string, dgsot::SensorValues>& SensorsIn)
+{
+  // The first time we read the sensors, we need to copy the state of the
+  // robot into the signal device.state.
+  setSensors(SensorsIn);
+  setState(robotState_(0));
+}
 
 void SoTTalosDevice::nominalSetSensors(map<string, dgsot::SensorValues>& SensorsIn) { setSensors(SensorsIn); }
 


### PR DESCRIPTION
  Formerly the Stack of Tasks started from a prespecified configuration.
  Starting from another configuration caused the robot to quickly move
  to the prespecified configuration. This commit fixes this undesired
  behavior.